### PR TITLE
Remove use of AWS stage server

### DIFF
--- a/crashes.py
+++ b/crashes.py
@@ -70,7 +70,7 @@ from fx_crash_sig.crash_processor import CrashProcessor
 ###########################################################
 
 # The default symbolication server to use.
-SymbolServerUrl = "https://symbolication.stage.mozaws.net/symbolicate/v5"
+SymbolServerUrl = "https://symbolication.services.mozilla.com/symbolicate/v5"
 # Max stack depth for symbolication
 MaxStackDepth = 50
 # Maximum number of raw crashes to process. This matches


### PR DESCRIPTION
This removes the host that pointed to the stage environment in AWS for the Mozilla Symbolication Service. That host no longer works.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1836055